### PR TITLE
Mutation fix

### DIFF
--- a/src/kibana/components/vislib/lib/y_axis.js
+++ b/src/kibana/components/vislib/lib/y_axis.js
@@ -15,8 +15,8 @@ define(function (require) {
      */
     function YAxis(args) {
       this.el = args.el;
-      this.yMin = args.yMin;
-      this.yMax = args.yMax;
+      this.yMin = args.yMin || 0;
+      this.yMax = args.yMax || 0;
       this._attr = _.defaults(args._attr || {}, {});
     }
 

--- a/src/kibana/components/vislib/vis.js
+++ b/src/kibana/components/vislib/vis.js
@@ -25,7 +25,7 @@ define(function (require) {
       Vis.Super.apply(this, arguments);
       this.el = $el.get ? $el.get(0) : $el;
       this.ChartClass = chartTypes[config.type];
-      this._attr = _.defaults(config || {}, {
+      this._attr = _.defaults({}, config || {}, {
         defaultYMin: true
       });
       this.eventTypes = {

--- a/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
+++ b/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
@@ -84,7 +84,7 @@ define(function (require) {
           }
         }, mockVisType)
       };
-      var $el = 'element';
+      var $el = $('<div>testing</div>');
       var createVisSpy;
       var getParamsStub;
       var renderbot;

--- a/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
+++ b/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
@@ -24,7 +24,6 @@ define(function (require) {
         Renderbot = Private(require('plugins/vis_types/_renderbot'));
         VislibRenderbot = Private(require('plugins/vis_types/vislib/_vislib_renderbot'));
         normalizeChartData = Private(require('components/agg_response/index'));
-
       });
     }
 
@@ -100,7 +99,7 @@ define(function (require) {
       it('should create a new Vis object when params change', function () {
         // called on init
         expect(createVisSpy.callCount).to.be(1);
-        renderbot.updateParams(_.clone(params));
+        renderbot.updateParams();
         // not called again, same params
         expect(createVisSpy.callCount).to.be(1);
         renderbot.vis.params = { one: 'fishy', two: 'fishy' };


### PR DESCRIPTION
Fixes the 2 failing tests at https://github.com/elasticsearch/kibana/pull/2680
- Assign default `yMin` and `yMax` values, if none were specified.
- Stop `_.defaults` from mutating the renderbot config

Also fixes the call to `renderbot.updateParams` - it doesn't take any parameters.
