### PR TITLE
Mutation fix

### DIFF
--- a/src/kibana/components/vislib/vis.js
+++ b/src/kibana/components/vislib/vis.js
@@ -25,7 +25,7 @@ define(function (require) {
       Vis.Super.apply(this, arguments);
       this.el = $el.get ? $el.get(0) : $el;
       this.ChartClass = chartTypes[config.type];
-      this._attr = _.defaults(config || {}, {
+      this._attr = _.defaults({}, config || {}, {
         defaultYMin: true
       });
       this.eventTypes = {

--- a/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
+++ b/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
@@ -84,7 +84,7 @@ define(function (require) {
           }
         }, mockVisType)
       };
-      var $el = 'element';
+      var $el = $('<div>testing</div>');
       var createVisSpy;
       var getParamsStub;
       var renderbot;

--- a/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
+++ b/test/unit/specs/plugins/vis_types/vislib/_renderbot.js
@@ -24,7 +24,6 @@ define(function (require) {
         Renderbot = Private(require('plugins/vis_types/_renderbot'));
         VislibRenderbot = Private(require('plugins/vis_types/vislib/_vislib_renderbot'));
         normalizeChartData = Private(require('components/agg_response/index'));
-
       });
     }
 
@@ -100,7 +99,7 @@ define(function (require) {
       it('should create a new Vis object when params change', function () {
         // called on init
         expect(createVisSpy.callCount).to.be(1);
-        renderbot.updateParams(_.clone(params));
+        renderbot.updateParams();
         // not called again, same params
         expect(createVisSpy.callCount).to.be(1);
         renderbot.vis.params = { one: 'fishy', two: 'fishy' };


### PR DESCRIPTION
- Fixes the the other failing tests at elasticsearch#2680 by preventing `_.defaults` from mutating the `renderbot` config.
- Fixes the call to renderbot.updateParams - it doesn't take any parameters.
- Fixes `$el` reference in test - should be a DOM element, not a string
