### PR TITLE
Formatter tests

### DIFF
--- a/src/kibana/components/vislib/visualizations/_chart.js
+++ b/src/kibana/components/vislib/visualizations/_chart.js
@@ -63,9 +63,11 @@ define(function (require) {
       var labels = this.handler.data.labels;
 
       function resolveLabel(datum) {
+        var fieldFormatter = datum && datum.aggConfig ? datum.aggConfig.fieldFormatter() : String;
+
         if (labels.length === 1) return labels[0];
         if (datum[0]) return datum[0][labelProp];
-        return datum[labelProp];
+        return fieldFormatter(datum[labelProp]);
       }
 
       selection.each(function (datum) {

--- a/src/kibana/components/vislib/visualizations/_chart.js
+++ b/src/kibana/components/vislib/visualizations/_chart.js
@@ -52,6 +52,14 @@ define(function (require) {
       selection.call(this.draw());
     };
 
+    Chart.prototype._resolveLabel = function (labelProp, labels, datum) {
+      var fieldFormatter = datum && datum.aggConfig ? datum.aggConfig.fieldFormatter() : String;
+
+      if (labels.length === 1) return labels[0];
+      if (datum[0]) return datum[0][labelProp];
+      return fieldFormatter(datum[labelProp]);
+    };
+
     /**
      * Append the data label to the element
      *
@@ -61,17 +69,10 @@ define(function (require) {
     Chart.prototype._addIdentifier = function (selection, labelProp) {
       labelProp = labelProp || 'label';
       var labels = this.handler.data.labels;
-
-      function resolveLabel(datum) {
-        var fieldFormatter = datum && datum.aggConfig ? datum.aggConfig.fieldFormatter() : String;
-
-        if (labels.length === 1) return labels[0];
-        if (datum[0]) return datum[0][labelProp];
-        return fieldFormatter(datum[labelProp]);
-      }
+      var self = this;
 
       selection.each(function (datum) {
-        var label = resolveLabel(datum);
+        var label = self._resolveLabel(labelProp, labels, datum);
         if (label != null) dataLabel(this, label);
       });
     };

--- a/test/unit/specs/vislib/visualizations/chart.js
+++ b/test/unit/specs/vislib/visualizations/chart.js
@@ -116,18 +116,29 @@ define(function (require) {
       expect(myChart instanceof Chart).to.be(true);
     });
 
-    it('should return properly formatted values based on the field formatter', function () {
+    it('should format label as String by default', function () {
       var datum = {
-        label: 1408734060000,
-        aggConfig: {
-          fieldFormatter: function () {
-            return function (d) { return String(d); };
-          }
-        }
+        label: 1408734060000
       };
       var labels = [1, 2, 3];
       var label = myChart._resolveLabel('label', labels, datum);
       expect(label).to.be(String(datum.label));
+    });
+
+    it('should use the aggConfig field formatter', function () {
+      var formatter = function (d) {
+        return String(d) + ' test';
+      };
+
+      var datum = {
+        label: 1408734060000,
+        aggConfig: {
+          fieldFormatter: function () { return formatter; }
+        }
+      };
+      var labels = [1, 2, 3];
+      var label = myChart._resolveLabel('label', labels, datum);
+      expect(label).to.be(formatter(datum.label));
     });
 
     it('should have a render method', function () {

--- a/test/unit/specs/vislib/visualizations/chart.js
+++ b/test/unit/specs/vislib/visualizations/chart.js
@@ -116,6 +116,20 @@ define(function (require) {
       expect(myChart instanceof Chart).to.be(true);
     });
 
+    it('should return properly formatted values based on the field formatter', function () {
+      var datum = {
+        label: 1408734060000,
+        aggConfig: {
+          fieldFormatter: function () {
+            return function (d) { return new Date(d); };
+          }
+        }
+      };
+      var labels = [1, 2, 3];
+      var label = myChart._resolveLabel('label', labels, datum);
+      expect(label).to.be.a(Date);
+    });
+
     it('should have a render method', function () {
       expect(typeof myChart.render === 'function').to.be(true);
     });

--- a/test/unit/specs/vislib/visualizations/chart.js
+++ b/test/unit/specs/vislib/visualizations/chart.js
@@ -121,13 +121,13 @@ define(function (require) {
         label: 1408734060000,
         aggConfig: {
           fieldFormatter: function () {
-            return function (d) { return new Date(d); };
+            return function (d) { return String(d); };
           }
         }
       };
       var labels = [1, 2, 3];
       var label = myChart._resolveLabel('label', labels, datum);
-      expect(label).to.be.a(Date);
+      expect(label).to.be(String(datum.label));
     });
 
     it('should have a render method', function () {


### PR DESCRIPTION
Amendment to elastic/kibana#3900

Make the field formatter in the test something other than `String`, to ensure it's actually being used.
