### PR TITLE
Fix point series stacking

### DIFF
--- a/src/kibana/components/vislib/visualizations/_point_series_chart.js
+++ b/src/kibana/components/vislib/visualizations/_point_series_chart.js
@@ -28,11 +28,9 @@ define(function (require) {
 
         if (y >= 0) {
           d.y0 = currentStackOffsets[1];
-          d.y = y;
           currentStackOffsets[1] += y;
         } else {
-          d.y0 = currentStackOffsets[0] + y;
-          d.y = -y;
+          d.y0 = currentStackOffsets[0];
           currentStackOffsets[0] += y;
         }
       };

--- a/src/kibana/components/vislib/visualizations/_point_series_chart.js
+++ b/src/kibana/components/vislib/visualizations/_point_series_chart.js
@@ -16,15 +16,18 @@ define(function (require) {
     }
 
     PointSeriesChart.prototype._stackMixedValues = function (stackCount) {
-      var currentStackOffsets = [];
+      var currentStackOffsets = [0, 0];
       var currentStackIndex = 0;
 
       return function (d, y0, y) {
-        if (currentStackIndex++ % stackCount === 0) {
+        var firstStack = currentStackIndex % stackCount === 0;
+        var lastStack = ++currentStackIndex === stackCount;
 
-          // if the current stack index has reached the final stack, reset the stack count
+        if (firstStack) {
           currentStackOffsets = [0, 0];
         }
+
+        if (lastStack) currentStackIndex = 0;
 
         if (y >= 0) {
           d.y0 = currentStackOffsets[1];

--- a/test/unit/specs/vislib/visualizations/column_chart.js
+++ b/test/unit/specs/vislib/visualizations/column_chart.js
@@ -11,41 +11,31 @@ define(function (require) {
   var termsColumns = require('vislib_fixtures/mock_data/terms/_columns');
   //var histogramRows = require('vislib_fixtures/mock_data/histogram/_rows');
   var stackedSeries = require('vislib_fixtures/mock_data/date_histogram/_stacked_series');
-  var dataArray = [
-    series,
-    seriesPosNeg,
-    seriesNeg,
-    termsColumns,
-    //histogramRows,
-    stackedSeries
-  ];
-  var names = [
-    'series',
-    'series with positive and negative values',
-    'series with negative values',
-    'terms columns',
-    //'histogram rows',
-    'stackedSeries'
-  ];
-  var modes = [
-    'stacked',
-    'stacked',
-    'stacked',
-    'grouped',
-    //'percentage',
-    'stacked'
+
+  // tuple, with the format [description, mode, data]
+  var dataTypesArray = [
+    ['series', 'stacked', series],
+    ['series with positive and negative values', 'stacked', seriesPosNeg],
+    ['series with negative values', 'stacked', seriesNeg],
+    ['terms columns', 'grouped', termsColumns],
+    // ['histogram rows', 'percentage', histogramRows],
+    ['stackedSeries', 'stacked', stackedSeries],
   ];
 
   angular.module('ColumnChartFactory', ['kibana']);
 
-  dataArray.forEach(function (data, i) {
-    describe('VisLib Column Chart Test Suite for ' + names[i] + ' Data', function () {
+  dataTypesArray.forEach(function (dataType, i) {
+    var name = dataType[0];
+    var mode = dataType[1];
+    var data = dataType[2];
+
+    describe('VisLib Column Chart Test Suite for ' + name + ' Data', function () {
       var vis;
       var visLibParams = {
         type: 'histogram',
         addLegend: true,
         addTooltip: true,
-        mode: modes[i]
+        mode: mode
       };
 
       beforeEach(function () {


### PR DESCRIPTION
The point series code wasn't handling negative values correctly, and it wasn't resetting the counter, which could have potentially caused other bugs as well.
- Don't mutate original data object (leave d.y alone)
- Fix offset usage for negative values
- Reset stack index counter
- Refactor column chart tests (reorganize how the data sources work)
